### PR TITLE
Remove unused global output directory config

### DIFF
--- a/global_ncp_change_analysis.yml
+++ b/global_ncp_change_analysis.yml
@@ -1,7 +1,6 @@
 [project]
 name = global_ncp_change_analysis
 global_work_dir = ./workdir
-global_output_dir = ./output
 log_level = INFO
 
 [job:country]

--- a/global_ncp_change_analysis_accountforfinite.yml
+++ b/global_ncp_change_analysis_accountforfinite.yml
@@ -1,7 +1,6 @@
 [project]
 name = global_ncp_change_analysis_accountforfinite
 global_work_dir = ./workdir
-global_output_dir = ./output
 log_level = INFO
 
 [job:country]

--- a/runner.py
+++ b/runner.py
@@ -108,7 +108,7 @@ def parse_and_validate_config(cfg_path: Path) -> dict:
     Returns:
         A dictionary with two top-level keys:
             - `project`: A dict containing validated project-level settings
-              (`name`, `global_work_dir`, `global_output_dir`, `log_level`).
+              (`name`, `global_work_dir`, `log_level`).
             - `job_list`: A list of dicts, one per job, containing validated and
               resolved job configuration, including paths, fields, operations, and
               output locations.
@@ -142,10 +142,6 @@ def parse_and_validate_config(cfg_path: Path) -> dict:
     global_work_dir = Path(config["project"]["global_work_dir"].strip())
     if not global_work_dir.is_absolute():
         global_work_dir = cfg_dir / global_work_dir
-
-    global_output_dir = Path(config["project"]["global_output_dir"].strip())
-    if not global_output_dir.is_absolute():
-        global_output_dir = cfg_dir / global_output_dir
 
     job_tags = []
     jobs_sections = []
@@ -289,9 +285,7 @@ def parse_and_validate_config(cfg_path: Path) -> dict:
                     f"Available fields: {sorted(props.keys())}"
                 )
 
-        outdir = global_output_dir
         workdir = global_work_dir / Path(tag)
-        outdir.mkdir(parents=True, exist_ok=True)
         workdir.mkdir(parents=True, exist_ok=True)
 
         base_raster_path_list = []
@@ -376,7 +370,6 @@ def parse_and_validate_config(cfg_path: Path) -> dict:
         "project": {
             "name": project_name,
             "global_work_dir": global_work_dir,
-            "global_output_dir": global_output_dir,
             "log_level": log_level_str,
         },
         "job_list": job_list,

--- a/test.yml
+++ b/test.yml
@@ -1,7 +1,6 @@
 [project]
 name = test
 global_work_dir = ./workdir
-global_output_dir = ./output
 log_level = INFO
 
 [job:country]


### PR DESCRIPTION
## Summary
- Stop requiring `[project].global_output_dir` in runner configs.
- Remove the unused global output directory parse/create/metadata plumbing from `runner.py`.
- Remove `global_output_dir` from tracked runner config files that had it.

Closes #17

## Testing
- `python -m py_compile runner.py`
- `python -c "import ast, pathlib; ast.parse(pathlib.Path('runner.py').read_text())"`
- `python -c "import configparser; files=['global_ncp_change_analysis.yml','global_ncp_change_analysis_accountforfinite.yml','test.yml']; [configparser.ConfigParser(interpolation=None).read(f) for f in files]; print('configparser read ok')"`
- `git diff --check`
- `rg -n "global_output_dir" -g "*.py" -g "*.yml" -g "*.yaml"` returned no matches.

## Notes
- This does not change per-job `output_csv` handling or timestamping behavior.