### PR TITLE
Cache zonal rasterization intermediates

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -1584,7 +1584,15 @@ def main():
     task_graph = taskgraph.TaskGraph(Path.cwd(), os.cpu_count() // 2 + 1, 15.0)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     thread_list = []
+    thread_error_list = []
     total_job_count = 0
+
+    def _run_zonal_stats_job_thread(output_csv, job_kwargs):
+        try:
+            run_zonal_stats_job(**job_kwargs)
+        except Exception as error:
+            logger.exception("job failed for output %s", output_csv)
+            thread_error_list.append((output_csv, error))
 
     for config_path in args.configs:
         cfg_path = Path(config_path)
@@ -1603,7 +1611,10 @@ def main():
             job["output_csv"] = output_path_timestamped
             job["task_graph"] = task_graph
 
-            thread = Thread(target=run_zonal_stats_job, kwargs=job)
+            thread = Thread(
+                target=_run_zonal_stats_job_thread,
+                args=(output_path_timestamped, job),
+            )
             thread.start()
             thread_list.append((output_path_timestamped, thread))
             total_job_count += 1
@@ -1611,7 +1622,15 @@ def main():
 
     for output_csv, thread in thread_list:
         thread.join()
-        logger.info(f"********* {output_csv} is complete!")
+        if not any(error_path == output_csv for error_path, _ in thread_error_list):
+            logger.info(f"********* {output_csv} is complete!")
+
+    if thread_error_list:
+        task_graph.close()
+        failed_outputs = ", ".join(str(path) for path, _ in thread_error_list)
+        raise RuntimeError(f"zonal statistics jobs failed: {failed_outputs}") from (
+            thread_error_list[0][1]
+        )
 
     task_graph.join()
     task_graph.close()

--- a/runner.py
+++ b/runner.py
@@ -8,7 +8,6 @@ import collections
 import argparse
 import configparser
 import glob
-import hashlib
 import logging
 import os
 import shutil
@@ -52,70 +51,6 @@ def _safe_path_stem(path, max_length=60):
     return (safe_stem or "unnamed")[:max_length]
 
 
-def _unlink_path_family(path):
-    """Remove a path and common sidecar files if they exist."""
-    path = Path(path)
-    path.unlink(missing_ok=True)
-    for suffix in (".aux.xml", "-wal", "-shm"):
-        Path(f"{path}{suffix}").unlink(missing_ok=True)
-
-
-def _make_zonal_cache_dir(
-    working_dir,
-    raster_path,
-    raster_band_index,
-    aggregate_vector_path,
-    aggregate_layer_name,
-    aggregate_vector_fields,
-    raster_info,
-    simplify_tolerance,
-):
-    """Build a deterministic per-raster/vector cache directory."""
-    working_dir = Path(working_dir) if working_dir else Path(tempfile.gettempdir())
-    raster_path = Path(raster_path)
-    aggregate_vector_path = Path(aggregate_vector_path)
-    key_parts = [
-        str(raster_path.resolve()),
-        str(raster_path.stat().st_mtime_ns),
-        str(raster_band_index),
-        str(aggregate_vector_path.resolve()),
-        str(aggregate_vector_path.stat().st_mtime_ns),
-        str(aggregate_layer_name),
-        ",".join(aggregate_vector_fields),
-        repr(raster_info["pixel_size"]),
-        repr(raster_info["bounding_box"]),
-        str(raster_info["projection_wkt"]),
-        repr(simplify_tolerance),
-    ]
-    cache_hash = hashlib.sha1("|".join(key_parts).encode("utf-8")).hexdigest()[:16]
-    cache_name = (
-        f"{_safe_path_stem(raster_path)}__"
-        f"{_safe_path_stem(aggregate_vector_path)}__{cache_hash}"
-    )
-    return working_dir / "fast_zonal_statistics_cache" / cache_name
-
-
-def _open_vector_layer(vector_path, layer_name, vector_label, writable=False):
-    open_flags = gdal.OF_VECTOR | (gdal.OF_UPDATE if writable else 0)
-    vector_dataset = gdal.OpenEx(str(vector_path), open_flags)
-    if vector_dataset is None:
-        raise RuntimeError(f"Could not open {vector_label} vector at {vector_path}")
-
-    if layer_name is not None:
-        logger.info("selecting %s layer by name: %s", vector_label, layer_name)
-        vector_layer = vector_dataset.GetLayerByName(layer_name)
-    else:
-        logger.info("selecting default %s layer", vector_label)
-        vector_layer = vector_dataset.GetLayer()
-
-    if vector_layer is None:
-        raise RuntimeError(
-            f"Could not open layer {layer_name} on {vector_label} vector {vector_path}"
-        )
-
-    return vector_dataset, vector_layer
-
-
 def _prepare_aggregate_vector_for_rasterization(
     aggregate_vector_path,
     aggregate_layer_name,
@@ -124,17 +59,17 @@ def _prepare_aggregate_vector_for_rasterization(
     simplify_tolerance,
     needs_reproject,
 ):
-    """Project/simplify aggregation vector and add stable feature IDs."""
+    """Project/simplify aggregation vector and add a FID burn field."""
     target_vector_path = Path(target_vector_path)
     target_vector_path.parent.mkdir(parents=True, exist_ok=True)
-    _unlink_path_family(target_vector_path)
+    target_vector_path.unlink(missing_ok=True)
 
     vector_translate_kwargs = {"format": "GPKG"}
     src_path = str(aggregate_vector_path)
     tmp_reprojected_path = None
     if needs_reproject:
         tmp_reprojected_path = target_vector_path.with_suffix(".reprojected.gpkg")
-        _unlink_path_family(tmp_reprojected_path)
+        tmp_reprojected_path.unlink(missing_ok=True)
         logger.info(
             "vector translate (reproject) start | output=%s | reproject=%s",
             tmp_reprojected_path,
@@ -161,16 +96,19 @@ def _prepare_aggregate_vector_for_rasterization(
         **vector_translate_kwargs,
     )
     if tmp_reprojected_path:
-        _unlink_path_family(tmp_reprojected_path)
+        tmp_reprojected_path.unlink(missing_ok=True)
 
-    aggregate_vector, aggregate_layer = _open_vector_layer(
-        target_vector_path,
-        aggregate_layer_name,
-        "prepared",
-        writable=True,
+    aggregate_vector = gdal.OpenEx(
+        str(target_vector_path), gdal.OF_VECTOR | gdal.OF_UPDATE
+    )
+    aggregate_layer = (
+        aggregate_vector.GetLayerByName(aggregate_layer_name)
+        if aggregate_layer_name is not None
+        else aggregate_vector.GetLayer()
     )
 
     local_aggregate_field_name = "original_fid"
+    # RasterizeLayer burns attribute values, so persist the OGR FID as a field.
     if aggregate_layer.FindFieldIndex(local_aggregate_field_name, 1) == -1:
         aggregate_layer.CreateField(
             ogr.FieldDefn(local_aggregate_field_name, ogr.OFTInteger)
@@ -198,7 +136,7 @@ def _rasterize_aggregate_fids(
     """Rasterize prepared aggregation feature IDs onto the base raster grid."""
     target_raster_path = Path(target_raster_path)
     target_raster_path.parent.mkdir(parents=True, exist_ok=True)
-    _unlink_path_family(target_raster_path)
+    target_raster_path.unlink(missing_ok=True)
 
     logger.info("creating agg fid raster: %s", target_raster_path)
     geoprocessing.new_raster_from_base(
@@ -208,10 +146,11 @@ def _rasterize_aggregate_fids(
         [target_nodata],
     )
 
-    aggregate_vector, aggregate_layer = _open_vector_layer(
-        aggregate_vector_path,
-        aggregate_layer_name,
-        "prepared",
+    aggregate_vector = gdal.OpenEx(str(aggregate_vector_path), gdal.OF_VECTOR)
+    aggregate_layer = (
+        aggregate_vector.GetLayerByName(aggregate_layer_name)
+        if aggregate_layer_name is not None
+        else aggregate_vector.GetLayer()
     )
     feature_id_raster_dataset = gdal.OpenEx(
         str(target_raster_path), gdal.GA_Update | gdal.OF_RASTER
@@ -664,8 +603,11 @@ def fast_zonal_statistics(
     raster_srs.ImportFromWkt(raster_info["projection_wkt"])
     raster_srs.SetAxisMappingStrategy(osr.OAMS_TRADITIONAL_GIS_ORDER)
 
-    source_vector, source_layer = _open_vector_layer(
-        aggregate_vector_path, aggregate_layer_name, "source"
+    source_vector = gdal.OpenEx(str(aggregate_vector_path), gdal.OF_VECTOR)
+    source_layer = (
+        source_vector.GetLayerByName(aggregate_layer_name)
+        if aggregate_layer_name is not None
+        else source_vector.GetLayer()
     )
 
     source_srs = source_layer.GetSpatialRef()
@@ -681,15 +623,11 @@ def fast_zonal_statistics(
     source_layer = None
     source_vector = None
 
-    cache_working_dir = _make_zonal_cache_dir(
-        working_dir,
-        raster_path,
-        raster_band_index,
-        aggregate_vector_path,
-        aggregate_layer_name,
-        aggregate_vector_fields,
-        raster_info,
-        simplify_tolerance,
+    working_dir = Path(working_dir) if working_dir else Path(tempfile.gettempdir())
+    cache_working_dir = (
+        working_dir
+        / "fast_zonal_statistics_cache"
+        / f"{_safe_path_stem(raster_path)}_band{raster_band_index}"
     )
     cache_working_dir.mkdir(parents=True, exist_ok=True)
     projected_vector_path = cache_working_dir / "projected_vector.gpkg"
@@ -721,10 +659,11 @@ def fast_zonal_statistics(
         )
         prepare_vector_task.join()
 
-        aggregate_vector, aggregate_layer = _open_vector_layer(
-            projected_vector_path,
-            aggregate_layer_name,
-            "projected",
+        aggregate_vector = gdal.OpenEx(str(projected_vector_path), gdal.OF_VECTOR)
+        aggregate_layer = (
+            aggregate_vector.GetLayerByName(aggregate_layer_name)
+            if aggregate_layer_name is not None
+            else aggregate_vector.GetLayer()
         )
 
         logger.info(

--- a/runner.py
+++ b/runner.py
@@ -8,6 +8,7 @@ import collections
 import argparse
 import configparser
 import glob
+import hashlib
 import logging
 import os
 import shutil
@@ -40,6 +41,208 @@ VALID_OPERATIONS = {
     "total_count",
     "valid_count",
 }
+
+
+def _safe_path_stem(path, max_length=60):
+    """Return a filesystem-safe abbreviated stem for cache directory names."""
+    safe_stem = "".join(
+        char if char.isalnum() or char in ("-", "_") else "_"
+        for char in Path(path).stem
+    )
+    return (safe_stem or "unnamed")[:max_length]
+
+
+def _unlink_path_family(path):
+    """Remove a path and common sidecar files if they exist."""
+    path = Path(path)
+    path.unlink(missing_ok=True)
+    for suffix in (".aux.xml", "-wal", "-shm"):
+        Path(f"{path}{suffix}").unlink(missing_ok=True)
+
+
+def _make_zonal_cache_dir(
+    working_dir,
+    raster_path,
+    raster_band_index,
+    aggregate_vector_path,
+    aggregate_layer_name,
+    aggregate_vector_fields,
+    raster_info,
+    simplify_tolerance,
+):
+    """Build a deterministic per-raster/vector cache directory."""
+    working_dir = Path(working_dir) if working_dir else Path(tempfile.gettempdir())
+    raster_path = Path(raster_path)
+    aggregate_vector_path = Path(aggregate_vector_path)
+    key_parts = [
+        str(raster_path.resolve()),
+        str(raster_path.stat().st_mtime_ns),
+        str(raster_band_index),
+        str(aggregate_vector_path.resolve()),
+        str(aggregate_vector_path.stat().st_mtime_ns),
+        str(aggregate_layer_name),
+        ",".join(aggregate_vector_fields),
+        repr(raster_info["pixel_size"]),
+        repr(raster_info["bounding_box"]),
+        str(raster_info["projection_wkt"]),
+        repr(simplify_tolerance),
+    ]
+    cache_hash = hashlib.sha1("|".join(key_parts).encode("utf-8")).hexdigest()[:16]
+    cache_name = (
+        f"{_safe_path_stem(raster_path)}__"
+        f"{_safe_path_stem(aggregate_vector_path)}__{cache_hash}"
+    )
+    return working_dir / "fast_zonal_statistics_cache" / cache_name
+
+
+def _open_vector_layer(vector_path, layer_name, vector_label, writable=False):
+    open_flags = gdal.OF_VECTOR | (gdal.OF_UPDATE if writable else 0)
+    vector_dataset = gdal.OpenEx(str(vector_path), open_flags)
+    if vector_dataset is None:
+        raise RuntimeError(f"Could not open {vector_label} vector at {vector_path}")
+
+    if layer_name is not None:
+        logger.info("selecting %s layer by name: %s", vector_label, layer_name)
+        vector_layer = vector_dataset.GetLayerByName(layer_name)
+    else:
+        logger.info("selecting default %s layer", vector_label)
+        vector_layer = vector_dataset.GetLayer()
+
+    if vector_layer is None:
+        raise RuntimeError(
+            f"Could not open layer {layer_name} on {vector_label} vector {vector_path}"
+        )
+
+    return vector_dataset, vector_layer
+
+
+def _prepare_aggregate_vector_for_rasterization(
+    aggregate_vector_path,
+    aggregate_layer_name,
+    target_vector_path,
+    raster_projection_wkt,
+    simplify_tolerance,
+    needs_reproject,
+):
+    """Project/simplify aggregation vector and add stable feature IDs."""
+    target_vector_path = Path(target_vector_path)
+    target_vector_path.parent.mkdir(parents=True, exist_ok=True)
+    _unlink_path_family(target_vector_path)
+
+    vector_translate_kwargs = {"format": "GPKG"}
+    src_path = str(aggregate_vector_path)
+    tmp_reprojected_path = None
+    if needs_reproject:
+        tmp_reprojected_path = target_vector_path.with_suffix(".reprojected.gpkg")
+        _unlink_path_family(tmp_reprojected_path)
+        logger.info(
+            "vector translate (reproject) start | output=%s | reproject=%s",
+            tmp_reprojected_path,
+            needs_reproject,
+        )
+        gdal.VectorTranslate(
+            str(tmp_reprojected_path),
+            src_path,
+            dstSRS=raster_projection_wkt,
+            **vector_translate_kwargs,
+        )
+        src_path = str(tmp_reprojected_path)
+
+    logger.info(
+        "vector translate (simplify) start | output=%s | simplifyTolerance=%s | reproject=%s",
+        target_vector_path,
+        simplify_tolerance,
+        needs_reproject,
+    )
+    gdal.VectorTranslate(
+        str(target_vector_path),
+        src_path,
+        simplifyTolerance=simplify_tolerance,
+        **vector_translate_kwargs,
+    )
+    if tmp_reprojected_path:
+        _unlink_path_family(tmp_reprojected_path)
+
+    aggregate_vector, aggregate_layer = _open_vector_layer(
+        target_vector_path,
+        aggregate_layer_name,
+        "prepared",
+        writable=True,
+    )
+
+    local_aggregate_field_name = "original_fid"
+    if aggregate_layer.FindFieldIndex(local_aggregate_field_name, 1) == -1:
+        aggregate_layer.CreateField(
+            ogr.FieldDefn(local_aggregate_field_name, ogr.OFTInteger)
+        )
+
+    aggregate_layer.ResetReading()
+    aggregate_layer.StartTransaction()
+    for feature in aggregate_layer:
+        feature.SetField(local_aggregate_field_name, feature.GetFID())
+        aggregate_layer.SetFeature(feature)
+    aggregate_layer.CommitTransaction()
+    aggregate_layer = None
+    aggregate_vector = None
+
+    logger.info("vector translate done | output=%s", target_vector_path)
+
+
+def _rasterize_aggregate_fids(
+    base_raster_path,
+    aggregate_vector_path,
+    aggregate_layer_name,
+    target_raster_path,
+    target_nodata,
+):
+    """Rasterize prepared aggregation feature IDs onto the base raster grid."""
+    target_raster_path = Path(target_raster_path)
+    target_raster_path.parent.mkdir(parents=True, exist_ok=True)
+    _unlink_path_family(target_raster_path)
+
+    logger.info("creating agg fid raster: %s", target_raster_path)
+    geoprocessing.new_raster_from_base(
+        str(base_raster_path),
+        str(target_raster_path),
+        gdal.GDT_Int32,
+        [target_nodata],
+    )
+
+    aggregate_vector, aggregate_layer = _open_vector_layer(
+        aggregate_vector_path,
+        aggregate_layer_name,
+        "prepared",
+    )
+    feature_id_raster_dataset = gdal.OpenEx(
+        str(target_raster_path), gdal.GA_Update | gdal.OF_RASTER
+    )
+    if feature_id_raster_dataset is None:
+        raise RuntimeError(f"Could not open target raster at {target_raster_path}")
+
+    rasterize_callback = _make_logger_callback(
+        "rasterizing polygons %.1f%% complete %s"
+    )
+    aggregate_layer.ResetReading()
+    logger.info("rasterize start")
+    error_code = gdal.RasterizeLayer(
+        feature_id_raster_dataset,
+        [1],
+        aggregate_layer,
+        callback=rasterize_callback,
+        options=[
+            "ALL_TOUCHED=FALSE",
+            "ATTRIBUTE=original_fid",
+        ],
+    )
+    feature_id_raster_dataset.FlushCache()
+    feature_id_raster_dataset = None
+    aggregate_layer = None
+    aggregate_vector = None
+    if error_code != 0:
+        raise RuntimeError(
+            f"RasterizeLayer failed with error code {error_code} for {target_raster_path}"
+        )
+    logger.info("rasterize done")
 
 
 def _make_logger_callback(message):
@@ -390,7 +593,7 @@ def fast_zonal_statistics(
     aggregate_layer_name=None,
     ignore_nodata=True,
     working_dir=None,
-    clean_working_dir=True,
+    clean_working_dir=False,
     percentile_list=None,
 ):
     raster_path, raster_band_index = base_raster_path_band
@@ -445,26 +648,6 @@ def fast_zonal_statistics(
         "sumsq": 0.0,
     }
 
-    def _open_vector_layer(vector_path, layer_name, vector_label, writable=False):
-        open_flags = gdal.OF_VECTOR | (gdal.OF_UPDATE if writable else 0)
-        vector_dataset = gdal.OpenEx(str(vector_path), open_flags)
-        if vector_dataset is None:
-            raise RuntimeError(f"Could not open {vector_label} vector at {vector_path}")
-
-        if layer_name is not None:
-            logger.info("selecting %s layer by name: %s", vector_label, layer_name)
-            vector_layer = vector_dataset.GetLayerByName(layer_name)
-        else:
-            logger.info("selecting default %s layer", vector_label)
-            vector_layer = vector_dataset.GetLayer()
-
-        if vector_layer is None:
-            raise RuntimeError(
-                f"Could not open layer {layer_name} on {vector_label} vector {vector_path}"
-            )
-
-        return vector_dataset, vector_layer
-
     raster_info = geoprocessing.get_raster_info(raster_path)
     raster_nodata = raster_info["nodata"][raster_band_index - 1]
     raster_pixel_width = abs(raster_info["pixel_size"][0])
@@ -495,9 +678,26 @@ def fast_zonal_statistics(
     else:
         logger.info("vector SRS missing/unknown | forcing reprojection to raster SRS")
 
-    temp_working_dir = tempfile.mkdtemp(dir=working_dir)
-    projected_vector_path = os.path.join(temp_working_dir, "projected_vector.gpkg")
-    logger.info("created temp working dir: %s", temp_working_dir)
+    source_layer = None
+    source_vector = None
+
+    cache_working_dir = _make_zonal_cache_dir(
+        working_dir,
+        raster_path,
+        raster_band_index,
+        aggregate_vector_path,
+        aggregate_layer_name,
+        aggregate_vector_fields,
+        raster_info,
+        simplify_tolerance,
+    )
+    cache_working_dir.mkdir(parents=True, exist_ok=True)
+    projected_vector_path = cache_working_dir / "projected_vector.gpkg"
+    feature_id_raster_path = cache_working_dir / "agg_fid.tif"
+    local_task_graph = taskgraph.TaskGraph(
+        cache_working_dir / "taskgraph", 1, 15.0
+    )
+    logger.info("using zonal statistics cache dir: %s", cache_working_dir)
 
     def _raster_nodata_mask(value_array):
         finite_mask = np.isfinite(value_array)
@@ -506,51 +706,25 @@ def fast_zonal_statistics(
         return np.isclose(value_array, raster_nodata) | ~finite_mask
 
     try:
-        vector_translate_kwargs = {"format": "GPKG"}
-        src_path = str(aggregate_vector_path)
-        tmp_reprojected_path = None
-        if needs_reproject:
-            tmp_reprojected_path = Path(projected_vector_path).with_suffix(
-                ".reprojected.gpkg"
-            )
-
-            logger.info(
-                "vector translate (reproject) start | output=%s | reproject=%s",
-                tmp_reprojected_path,
+        prepare_vector_task = local_task_graph.add_task(
+            func=_prepare_aggregate_vector_for_rasterization,
+            args=(
+                aggregate_vector_path,
+                aggregate_layer_name,
+                projected_vector_path,
+                raster_info["projection_wkt"],
+                simplify_tolerance,
                 needs_reproject,
-            )
-            gdal.VectorTranslate(
-                str(tmp_reprojected_path),
-                src_path,
-                dstSRS=raster_info["projection_wkt"],
-                **vector_translate_kwargs,
-            )
-            src_path = str(tmp_reprojected_path)
-
-        logger.info(
-            "vector translate (simplify) start | output=%s | simplifyTolerance=%s | reproject=%s",
-            projected_vector_path,
-            simplify_tolerance,
-            needs_reproject,
+            ),
+            target_path_list=[projected_vector_path],
+            task_name=f"prepare aggregate vector for {Path(aggregate_vector_path).stem}",
         )
-        gdal.VectorTranslate(
-            str(projected_vector_path),
-            src_path,
-            simplifyTolerance=simplify_tolerance,
-            **vector_translate_kwargs,
-        )
-        if tmp_reprojected_path:
-            tmp_reprojected_path.unlink()
-
-        logger.info("vector translate done | output=%s", projected_vector_path)
-
-        source_layer = None
+        prepare_vector_task.join()
 
         aggregate_vector, aggregate_layer = _open_vector_layer(
             projected_vector_path,
             aggregate_layer_name,
             "projected",
-            writable=True,
         )
 
         logger.info(
@@ -629,30 +803,6 @@ def fast_zonal_statistics(
             raster_band_index,
         )
 
-        # we need to put an 'fid' code into the vector because otherwise we are
-        # not guarnateed to have one
-        local_aggregate_field_name = "original_fid"
-        if aggregate_layer.FindFieldIndex(local_aggregate_field_name, 1) == -1:
-            aggregate_layer.CreateField(
-                ogr.FieldDefn(local_aggregate_field_name, ogr.OFTInteger)
-            )
-
-        aggregate_layer.ResetReading()
-        aggregate_layer.StartTransaction()
-        for feat in aggregate_layer:
-            feat.SetField(local_aggregate_field_name, feat.GetFID())
-            aggregate_layer.SetFeature(feat)
-        aggregate_layer.CommitTransaction()
-        aggregate_layer.ResetReading()
-
-        local_aggregate_field_name = "original_fid"
-        rasterize_layer_args = {
-            "options": [
-                "ALL_TOUCHED=FALSE",
-                f"ATTRIBUTE={local_aggregate_field_name}",
-            ]
-        }
-
         logger.info(
             "disjoint sets ready total_features=%d",
             len(feature_id_set),
@@ -662,19 +812,28 @@ def fast_zonal_statistics(
             lambda: dict(feature_stats_template)
         )
 
-        feature_id_raster_path = os.path.join(temp_working_dir, "agg_fid.tif")
         feature_id_raster_nodata = -1
-        logger.info("creating agg fid raster: %s", feature_id_raster_path)
-        geoprocessing.new_raster_from_base(
-            raster_path_for_stats,
-            feature_id_raster_path,
-            gdal.GDT_Int32,
-            [feature_id_raster_nodata],
+        aggregate_layer = None
+        aggregate_vector = None
+
+        rasterize_task = local_task_graph.add_task(
+            func=_rasterize_aggregate_fids,
+            args=(
+                raster_path_for_stats,
+                projected_vector_path,
+                aggregate_layer_name,
+                feature_id_raster_path,
+                feature_id_raster_nodata,
+            ),
+            dependent_task_list=[prepare_vector_task],
+            target_path_list=[feature_id_raster_path],
+            task_name=f"rasterize aggregate fids for {Path(raster_path).stem}",
         )
+        rasterize_task.join()
 
         feature_id_raster_offsets = list(
             geoprocessing.iterblocks(
-                (feature_id_raster_path, 1),
+                (str(feature_id_raster_path), 1),
                 offset_only=True,
                 largest_block=2**28,
             )
@@ -685,27 +844,9 @@ def fast_zonal_statistics(
         )
 
         feature_id_raster_dataset = gdal.OpenEx(
-            feature_id_raster_path, gdal.GA_Update | gdal.OF_RASTER
+            str(feature_id_raster_path), gdal.OF_RASTER
         )
         feature_id_raster_band = feature_id_raster_dataset.GetRasterBand(1)
-
-        logger.info("populating disjoint layer features (transaction start)")
-        logger.info("populating disjoint layer features done (transaction commit)")
-
-        rasterize_callback_message = "rasterizing polygons %.1f%% complete %s"
-        rasterize_callback = _make_logger_callback(rasterize_callback_message)
-
-        logger.info("rasterize start")
-        aggregate_layer.ResetReading()
-        gdal.RasterizeLayer(
-            feature_id_raster_dataset,
-            [1],
-            aggregate_layer,
-            callback=rasterize_callback,
-            **rasterize_layer_args,
-        )
-        feature_id_raster_dataset.FlushCache()
-        logger.info("rasterize done")
 
         logger.info("gathering stats from raster blocks")
         block_log_time = time.time()
@@ -911,9 +1052,10 @@ def fast_zonal_statistics(
         logger.info("fast_zonal_statistics done")
         return dict(grouped_stats)
     finally:
+        local_task_graph.close()
         if clean_working_dir:
-            logger.info("cleaning temp working dir: %s", temp_working_dir)
-            shutil.rmtree(temp_working_dir)
+            logger.info("cleaning zonal statistics cache dir: %s", cache_working_dir)
+            shutil.rmtree(cache_working_dir)
 
 
 def run_vector_stats_job(
@@ -1309,7 +1451,7 @@ def run_zonal_stats_job(
                     "aggregate_layer_name": agg_layer,
                     "ignore_nodata": True,
                     "working_dir": workdir,
-                    "clean_working_dir": True,
+                    "clean_working_dir": False,
                     "percentile_list": pct_list,
                 },
                 store_result=True,


### PR DESCRIPTION
## Summary
- Replace random `fast_zonal_statistics` temp directories with deterministic cache directories under each job work directory.
- Move vector preparation and aggregation-FID rasterization into a nested taskgraph with an isolated taskgraph database per raster/vector cache.
- Keep `projected_vector.gpkg` and `agg_fid.tif` for future debugging and rerun reuse.
- Propagate exceptions raised inside per-job threads back to the main runner process.

Closes #19

## Testing
- `python -m py_compile runner.py`
- `python -c "import ast, pathlib; ast.parse(pathlib.Path('runner.py').read_text())"`
- `git diff --check HEAD~2..HEAD`

## Notes
- I could not reproduce the overnight hang from the partial tail log alone. The log shows the three remaining `fast_zonal_statistics` tasks still executing, not clearly failed, but the previous temp-directory behavior made it hard to tell whether rasterization had completed before the long-running block scan phase.
- Full runner execution was not run locally because this environment does not have the project geospatial Python stack installed outside the Docker/conda runtime.
- This preserves statistic calculations and output CSV behavior.