### PR TITLE
Add runner progress bars

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -9,7 +9,9 @@ import argparse
 import configparser
 import glob
 import logging
+import multiprocessing
 import os
+import queue
 import shutil
 import tempfile
 import time
@@ -30,7 +32,6 @@ logging.getLogger("fiona").setLevel(logging.WARNING)
 logger = logging.getLogger(__name__)
 
 
-_LOGGING_PERIOD = 10.0
 AREA_HECTARE_OPERATIONS = {
     "area_ha_total",
     "area_ha_valid",
@@ -53,6 +54,116 @@ VALID_OPERATIONS = {
     "total_count",
     "valid_count",
 }
+
+
+def _emit_progress(progress_queue, event):
+    """Send a progress event if a queue is configured.
+
+    Args:
+        progress_queue: Queue-like object receiving progress events, or `None`.
+        event: Pickleable event dictionary for the progress monitor.
+    """
+    if progress_queue is None:
+        return
+    try:
+        progress_queue.put(event)
+    except Exception:
+        logger.exception("failed to emit progress event: %s", event)
+
+
+def _progress_monitor(progress_queue, total_jobs):
+    """Render runner progress events as tqdm bars.
+
+    Args:
+        progress_queue: Queue-like object receiving progress event dictionaries.
+        total_jobs: Number of `[job:...]` sections expected to finish.
+    """
+    bars = {}
+    next_position = 1
+    job_bar = tqdm(
+        total=total_jobs,
+        desc="jobs",
+        unit="job",
+        position=0,
+        leave=True,
+    )
+
+    try:
+        while True:
+            try:
+                event = progress_queue.get(timeout=0.2)
+            except queue.Empty:
+                continue
+
+            event_type = event.get("event")
+            if event_type == "stop":
+                break
+
+            if event_type == "job_done":
+                job_bar.update(1)
+                job_bar.set_postfix_str(
+                    f'{event.get("tag", "job")} {event.get("status", "done")}',
+                    refresh=True,
+                )
+                continue
+
+            progress_id = event.get("id")
+            if not progress_id:
+                continue
+
+            if event_type == "analysis_start":
+                if progress_id in bars:
+                    bars[progress_id].close()
+                bars[progress_id] = tqdm(
+                    total=event.get("total", 1),
+                    desc=event.get("desc", progress_id),
+                    unit=event.get("unit", "step"),
+                    position=next_position,
+                    leave=True,
+                )
+                next_position += 1
+                phase = event.get("phase")
+                if phase:
+                    bars[progress_id].set_postfix_str(phase, refresh=True)
+                continue
+
+            progress_bar = bars.get(progress_id)
+            if progress_bar is None:
+                continue
+
+            if event_type == "analysis_total":
+                progress_bar.total = event.get("total", progress_bar.total)
+                progress_bar.unit = event.get("unit", progress_bar.unit)
+                phase = event.get("phase")
+                if phase:
+                    progress_bar.set_postfix_str(phase, refresh=True)
+                progress_bar.refresh()
+                continue
+
+            if event_type == "analysis_update":
+                increment = event.get("increment", 1)
+                if increment:
+                    progress_bar.update(increment)
+                phase = event.get("phase")
+                if phase:
+                    progress_bar.set_postfix_str(phase, refresh=True)
+                continue
+
+            if event_type == "analysis_close":
+                phase = event.get("phase")
+                if phase:
+                    progress_bar.set_postfix_str(phase, refresh=True)
+                if (
+                    progress_bar.total is not None
+                    and progress_bar.n < progress_bar.total
+                ):
+                    progress_bar.update(progress_bar.total - progress_bar.n)
+                progress_bar.close()
+                continue
+    finally:
+        for progress_bar in bars.values():
+            progress_bar.close()
+        job_bar.close()
 
 
 def _record_area_hectare_assumption(message):
@@ -703,10 +814,28 @@ def fast_zonal_statistics(
     clean_working_dir=False,
     percentile_list=None,
     calculate_area_ha=False,
+    progress_queue=None,
+    progress_id=None,
 ):
     raster_path, raster_band_index = base_raster_path_band
     aggregate_vector_fields = aggregate_vector_field
     aggregate_vector_field_label = ",".join(aggregate_vector_fields)
+    progress_id = (
+        progress_id
+        or f"raster:{Path(raster_path).stem}:{Path(aggregate_vector_path).stem}"
+    )
+    progress_n = 0
+    _emit_progress(
+        progress_queue,
+        {
+            "event": "analysis_start",
+            "id": progress_id,
+            "desc": f"raster {Path(raster_path).stem}",
+            "total": 5,
+            "unit": "step",
+            "phase": "loading inputs",
+        },
+    )
 
     logger.info(
         "fast_zonal_statistics start | raster=%s band=%s | vector=%s layer=%s "
@@ -812,9 +941,7 @@ def fast_zonal_statistics(
     cache_working_dir.mkdir(parents=True, exist_ok=True)
     projected_vector_path = cache_working_dir / "projected_vector.gpkg"
     feature_id_raster_path = cache_working_dir / "agg_fid.tif"
-    local_task_graph = taskgraph.TaskGraph(
-        cache_working_dir / "taskgraph", 1, 15.0
-    )
+    local_task_graph = taskgraph.TaskGraph(cache_working_dir / "taskgraph", 1, None)
     logger.info("using zonal statistics cache dir: %s", cache_working_dir)
 
     def _raster_nodata_mask(value_array):
@@ -838,6 +965,16 @@ def fast_zonal_statistics(
             task_name=f"prepare aggregate vector for {Path(aggregate_vector_path).stem}",
         )
         prepare_vector_task.join()
+        progress_n += 1
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_update",
+                "id": progress_id,
+                "increment": 1,
+                "phase": "scanning aggregation vector",
+            },
+        )
 
         aggregate_vector = gdal.OpenEx(str(projected_vector_path), gdal.OF_VECTOR)
         aggregate_layer = (
@@ -874,6 +1011,16 @@ def fast_zonal_statistics(
             aggregate_vector_field_label,
             len(unique_group_values),
         )
+        progress_n += 1
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_update",
+                "id": progress_id,
+                "increment": 1,
+                "phase": "checking extents",
+            },
+        )
 
         raster_bounding_box = raster_info["bounding_box"]
         vector_extent = aggregate_layer.GetExtent()
@@ -909,6 +1056,14 @@ def fast_zonal_statistics(
                 len(unique_group_values),
             )
             aggregate_layer = None
+            _emit_progress(
+                progress_queue,
+                {
+                    "event": "analysis_close",
+                    "id": progress_id,
+                    "phase": "no intersection",
+                },
+            )
             return grouped_stats
 
         raster_path_for_stats = raster_path
@@ -949,6 +1104,16 @@ def fast_zonal_statistics(
             task_name=f"rasterize aggregate fids for {Path(raster_path).stem}",
         )
         rasterize_task.join()
+        progress_n += 1
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_update",
+                "id": progress_id,
+                "increment": 1,
+                "phase": "preparing raster blocks",
+            },
+        )
 
         feature_id_raster_offsets = list(
             geoprocessing.iterblocks(
@@ -961,6 +1126,16 @@ def fast_zonal_statistics(
             "iterblocks prepared | blocks=%d",
             len(feature_id_raster_offsets),
         )
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_total",
+                "id": progress_id,
+                "total": progress_n + len(feature_id_raster_offsets) + 2,
+                "unit": "block",
+                "phase": "processing raster blocks",
+            },
+        )
 
         feature_id_raster_dataset = gdal.OpenEx(
             str(feature_id_raster_path), gdal.OF_RASTER
@@ -968,22 +1143,21 @@ def fast_zonal_statistics(
         feature_id_raster_band = feature_id_raster_dataset.GetRasterBand(1)
 
         logger.info("gathering stats from raster blocks")
-        block_log_time = time.time()
         group_sketch = None
         if percentile_list:
             group_sketch = defaultdict(lambda: kll_floats_sketch(k=200))
         for block_index, feature_id_offset in enumerate(feature_id_raster_offsets):
-            block_log_time = _invoke_timed_callback(
-                block_log_time,
-                lambda block_index_value=block_index: logger.info(
-                    "block processing | %.1f%% (%d/%d blocks)",
-                    100.0
-                    * float(block_index_value + 1)
-                    / len(feature_id_raster_offsets),
-                    block_index_value + 1,
-                    len(feature_id_raster_offsets),
-                ),
-                _LOGGING_PERIOD,
+            _emit_progress(
+                progress_queue,
+                {
+                    "event": "analysis_update",
+                    "id": progress_id,
+                    "increment": 1,
+                    "phase": (
+                        f"processing raster blocks {block_index + 1}/"
+                        f"{len(feature_id_raster_offsets)}"
+                    ),
+                },
             )
 
             feature_id_block = feature_id_raster_band.ReadAsArray(**feature_id_offset)
@@ -1034,6 +1208,16 @@ def fast_zonal_statistics(
                 )
 
         logger.info("aggregating done")
+        progress_n += len(feature_id_raster_offsets)
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_update",
+                "id": progress_id,
+                "increment": 1,
+                "phase": "grouping feature statistics",
+            },
+        )
 
         feature_id_raster_band = None
         feature_id_raster_dataset = None
@@ -1179,6 +1363,14 @@ def fast_zonal_statistics(
             )
         logger.info("grouping done | groups=%d", len(grouped_stats))
         logger.info("fast_zonal_statistics done")
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_close",
+                "id": progress_id,
+                "phase": "done",
+            },
+        )
         return dict(grouped_stats)
     finally:
         local_task_graph.close()
@@ -1198,6 +1390,7 @@ def run_vector_stats_job(
     workdir: Path,
     tag: str,
     job_type: str,
+    progress_queue=None,
 ):
     """Run a vector-based statistics job and write aggregated results to CSV.
 
@@ -1226,6 +1419,7 @@ def run_vector_stats_job(
         workdir: Working directory for intermediate job artifacts.
         tag: Job identifier used for logging and column name suffixes.
         job_type: Job type string; must be `"vector"`.
+        progress_queue: Optional queue for progress monitor events.
 
     Raises:
         ValueError: If `job_type` is not `"vector"` or if operation parsing fails.
@@ -1300,6 +1494,18 @@ def run_vector_stats_job(
     for base_vector_path in base_vector_path_list:
         base_vector_path = Path(base_vector_path)
         stem = base_vector_path.stem
+        progress_id = f"vector:{tag}:{stem}"
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_start",
+                "id": progress_id,
+                "desc": f"vector {tag}:{stem}",
+                "total": 3,
+                "unit": "step",
+                "phase": "reading vector",
+            },
+        )
 
         base_gdf = gpd.read_file(base_vector_path)
         keep_cols = [c for c in base_vector_fields if c in base_gdf.columns]
@@ -1313,6 +1519,15 @@ def run_vector_stats_job(
             base_gdf = base_gdf.to_crs(agg_crs)
 
         transformers_by_stem[stem] = transformer
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_update",
+                "id": progress_id,
+                "increment": 1,
+                "phase": "preparing nearest-neighbor chunks",
+            },
+        )
 
         feature_ids_all = base_gdf.index.to_numpy()
         geometries_all = base_gdf.geometry.values
@@ -1340,13 +1555,33 @@ def run_vector_stats_job(
             )
             for start_index in range(0, feature_count, chunk_size)
         ]
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_total",
+                "id": progress_id,
+                "total": len(nearest_tasks) + 2,
+                "unit": "chunk",
+                "phase": "finding closest aggregation geometry",
+            },
+        )
 
         with ThreadPoolExecutor() as executor:
-            for start_index, nearest_chunk in tqdm(
+            for chunk_index, (start_index, nearest_chunk) in enumerate(
                 executor.map(_nearest_chunk_thread, nearest_tasks, chunksize=1),
-                total=len(nearest_tasks),
-                desc=f"finding closest geom: {stem}",
             ):
+                _emit_progress(
+                    progress_queue,
+                    {
+                        "event": "analysis_update",
+                        "id": progress_id,
+                        "increment": 1,
+                        "phase": (
+                            f"finding closest aggregation geometry "
+                            f"{chunk_index + 1}/{len(nearest_tasks)}"
+                        ),
+                    },
+                )
                 nearest_group_index[
                     start_index : start_index + len(nearest_chunk)
                 ] = nearest_chunk
@@ -1363,6 +1598,15 @@ def run_vector_stats_job(
         }
 
         stem_frame = pd.DataFrame(group_keys, columns=agg_fields)
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_update",
+                "id": progress_id,
+                "increment": 0,
+                "phase": "summarizing vector attributes",
+            },
+        )
 
         if "total_count" in core_ops:
             stem_frame[f"total_count_{stem}"] = np.bincount(
@@ -1468,6 +1712,14 @@ def run_vector_stats_job(
                         stem_frame[column_name] = out
 
         per_stem_frames.append(stem_frame)
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_close",
+                "id": progress_id,
+                "phase": "done",
+            },
+        )
 
     if per_stem_frames:
         result_table = per_stem_frames[0]
@@ -1667,6 +1919,7 @@ def run_vector_measure_job(
     operation,
     measure_crs,
     tag,
+    progress_queue=None,
 ):
     """Run a vector-on-vector intersection measure job.
 
@@ -1680,10 +1933,23 @@ def run_vector_measure_job(
             `intersect_count`.
         measure_crs: CRS for planar measurement, or `auto`.
         tag: Job tag used in log and error messages.
+        progress_queue: Optional queue for progress monitor events.
 
     Returns:
         DataFrame containing aggregation fields and one measure column.
     """
+    progress_id = f"measure:{tag}:{Path(base_measure_vector).stem}"
+    _emit_progress(
+        progress_queue,
+        {
+            "event": "analysis_start",
+            "id": progress_id,
+            "desc": f"measure {tag}:{Path(base_measure_vector).stem}",
+            "total": 6,
+            "unit": "step",
+            "phase": "reading vectors",
+        },
+    )
     logger.info(
         "running vector measure job | tag=%s operation=%s base=%s layer=%s",
         tag,
@@ -1693,11 +1959,29 @@ def run_vector_measure_job(
     )
     agg_gdf = gpd.read_file(agg_vector, layer=agg_layer)
     measure_gdf = gpd.read_file(base_measure_vector, layer=base_measure_layer)
+    _emit_progress(
+        progress_queue,
+        {
+            "event": "analysis_update",
+            "id": progress_id,
+            "increment": 1,
+            "phase": "validating measure geometry",
+        },
+    )
     measure_gdf = measure_gdf[
         measure_gdf.geometry.notna() & (~measure_gdf.geometry.is_empty)
     ].copy()
     _validate_measure_geometry(measure_gdf, operation, base_measure_vector)
 
+    _emit_progress(
+        progress_queue,
+        {
+            "event": "analysis_update",
+            "id": progress_id,
+            "increment": 1,
+            "phase": "dissolving aggregation vector",
+        },
+    )
     agg_groups = agg_gdf.dissolve(by=agg_fields, as_index=False)
     agg_groups = agg_groups[agg_fields + ["geometry"]]
     column_name = f"{operation}_{Path(base_measure_vector).stem}"
@@ -1706,14 +1990,40 @@ def run_vector_measure_job(
 
     if measure_gdf.empty:
         logger.info("base measure vector has no non-empty geometries")
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_close",
+                "id": progress_id,
+                "phase": "no measure geometries",
+            },
+        )
         return result_table
 
     target_crs = _select_measure_crs(
         agg_groups, measure_gdf, measure_crs, operation, tag
     )
+    _emit_progress(
+        progress_queue,
+        {
+            "event": "analysis_update",
+            "id": progress_id,
+            "increment": 1,
+            "phase": "projecting vectors",
+        },
+    )
     agg_projected = agg_groups.to_crs(target_crs)
     measure_projected = measure_gdf[["geometry"]].to_crs(target_crs)
     measure_projected = measure_projected.explode(index_parts=False)
+    _emit_progress(
+        progress_queue,
+        {
+            "event": "analysis_update",
+            "id": progress_id,
+            "increment": 1,
+            "phase": "intersecting vectors",
+        },
+    )
 
     if operation == "intersect_count":
         joined = gpd.sjoin(
@@ -1723,6 +2033,14 @@ def run_vector_measure_job(
             predicate="intersects",
         )
         if joined.empty:
+            _emit_progress(
+                progress_queue,
+                {
+                    "event": "analysis_close",
+                    "id": progress_id,
+                    "phase": "no intersections",
+                },
+            )
             return result_table
         measured = (
             joined.groupby(agg_fields, dropna=False)
@@ -1738,6 +2056,14 @@ def run_vector_measure_job(
             keep_geom_type=False,
         )
         if intersection_gdf.empty:
+            _emit_progress(
+                progress_queue,
+                {
+                    "event": "analysis_close",
+                    "id": progress_id,
+                    "phase": "no intersections",
+                },
+            )
             return result_table
         linear_units_to_meters = _linear_units_to_meters(target_crs)
         if operation == "intersect_area_ha":
@@ -1756,6 +2082,15 @@ def run_vector_measure_job(
             .sum()
             .reset_index()
         )
+    _emit_progress(
+        progress_queue,
+        {
+            "event": "analysis_update",
+            "id": progress_id,
+            "increment": 1,
+            "phase": "merging measure results",
+        },
+    )
 
     result_table = result_table.drop(columns=[column_name]).merge(
         measured, on=agg_fields, how="left", sort=False
@@ -1763,6 +2098,14 @@ def run_vector_measure_job(
     result_table[column_name] = result_table[column_name].fillna(0)
     if operation == "intersect_count":
         result_table[column_name] = result_table[column_name].astype(np.int64)
+    _emit_progress(
+        progress_queue,
+        {
+            "event": "analysis_close",
+            "id": progress_id,
+            "phase": "done",
+        },
+    )
     return result_table
 
 
@@ -1821,6 +2164,7 @@ def run_zonal_stats_job(
     workdir: Path,
     tag: str,
     task_graph,
+    progress_queue=None,
 ):
     """Run a zonal statistics job over raster and/or vector base datasets.
 
@@ -1852,6 +2196,7 @@ def run_zonal_stats_job(
         workdir: Working directory for intermediate files and task graph outputs.
         tag: Job identifier used for temporary filenames and task labeling.
         task_graph: Task graph instance used to schedule raster and vector jobs.
+        progress_queue: Optional queue for progress monitor events.
 
     Raises:
         ValueError: If operation parsing fails or required inputs are inconsistent.
@@ -1883,6 +2228,7 @@ def run_zonal_stats_job(
             operation=core_ops[0],
             measure_crs=measure_crs,
             tag=tag,
+            progress_queue=progress_queue,
         )
         _write_zonal_outputs(
             combined_dataframe,
@@ -1912,6 +2258,8 @@ def run_zonal_stats_job(
                     "calculate_area_ha": bool(
                         AREA_HECTARE_OPERATIONS.intersection(core_ops)
                     ),
+                    "progress_queue": progress_queue,
+                    "progress_id": f"raster:{tag}:{base_raster_path.stem}",
                 },
                 store_result=True,
                 task_name=(
@@ -1941,6 +2289,7 @@ def run_zonal_stats_job(
                 "workdir": workdir,
                 "tag": tag,
                 "job_type": "vector",
+                "progress_queue": progress_queue,
             },
             task_name=f"vector stats for {tag}",
             target_path_list=[vector_tmp_csv],
@@ -2000,32 +2349,6 @@ def run_zonal_stats_job(
     )
 
 
-def _invoke_timed_callback(reference_time, callback_lambda, callback_period):
-    """Invoke callback if a certain amount of time has passed.
-
-    This is a convenience function to standardize update callbacks from the
-    module.
-
-    Args:
-        reference_time (float): time to base ``callback_period`` length from.
-        callback_lambda (lambda): function to invoke if difference between
-            current time and ``reference_time`` has exceeded
-            ``callback_period``.
-        callback_period (float): time in seconds to pass until
-            ``callback_lambda`` is invoked.
-
-    Return:
-        ``reference_time`` if ``callback_lambda`` not invoked, otherwise the
-        time when ``callback_lambda`` was invoked.
-
-    """
-    current_time = time.time()
-    if current_time - reference_time > callback_period:
-        callback_lambda()
-        return current_time
-    return reference_time
-
-
 def main():
     """CLI entrypoint for validating zonal-stats runner configurations.
 
@@ -2045,18 +2368,29 @@ def main():
         level=logging.DEBUG,
         format="%(asctime)s %(levelname)s %(name)s %(filename)s:%(lineno)d: %(message)s",
     )
-    task_graph = taskgraph.TaskGraph(Path.cwd(), os.cpu_count() // 2 + 1, 15.0)
+    task_graph = taskgraph.TaskGraph(Path.cwd(), os.cpu_count() // 2 + 1, None)
     timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
     thread_list = []
     thread_error_list = []
-    total_job_count = 0
+    job_run_list = []
 
     def _run_zonal_stats_job_thread(output_label, job_kwargs):
+        status = "done"
         try:
             run_zonal_stats_job(**job_kwargs)
         except Exception as error:
+            status = "failed"
             logger.exception("job failed for output %s", output_label)
             thread_error_list.append((output_label, error))
+        finally:
+            _emit_progress(
+                job_kwargs.get("progress_queue"),
+                {
+                    "event": "job_done",
+                    "tag": job_kwargs.get("tag"),
+                    "status": status,
+                },
+            )
 
     for config_path in args.configs:
         cfg_path = Path(config_path)
@@ -2082,30 +2416,48 @@ def main():
             output_label = ", ".join(
                 str(output_path) for output_path in output_path_list
             )
+            job_run_list.append((output_label, job))
 
+    total_job_count = len(job_run_list)
+    progress_manager = multiprocessing.Manager()
+    progress_queue = progress_manager.Queue()
+    progress_thread = Thread(
+        target=_progress_monitor,
+        args=(progress_queue, total_job_count),
+        daemon=True,
+    )
+    progress_thread.start()
+
+    try:
+        for output_label, job in job_run_list:
+            job["progress_queue"] = progress_queue
             thread = Thread(
                 target=_run_zonal_stats_job_thread,
                 args=(output_label, job),
             )
             thread.start()
             thread_list.append((output_label, thread))
-            total_job_count += 1
-    logger.info(f"******** running {total_job_count} jobs")
 
-    for output_label, thread in thread_list:
-        thread.join()
-        if not any(error_path == output_label for error_path, _ in thread_error_list):
-            logger.info(f"********* {output_label} is complete!")
+        logger.info(f"******** running {total_job_count} jobs")
 
-    if thread_error_list:
+        for output_label, thread in thread_list:
+            thread.join()
+            if not any(error_path == output_label for error_path, _ in thread_error_list):
+                logger.info(f"********* {output_label} is complete!")
+
+        if thread_error_list:
+            task_graph.close()
+            failed_outputs = ", ".join(str(path) for path, _ in thread_error_list)
+            raise RuntimeError(f"zonal statistics jobs failed: {failed_outputs}") from (
+                thread_error_list[0][1]
+            )
+
+        task_graph.join()
         task_graph.close()
-        failed_outputs = ", ".join(str(path) for path, _ in thread_error_list)
-        raise RuntimeError(f"zonal statistics jobs failed: {failed_outputs}") from (
-            thread_error_list[0][1]
-        )
-
-    task_graph.join()
-    task_graph.close()
+    finally:
+        _emit_progress(progress_queue, {"event": "stop"})
+        progress_thread.join()
+        progress_manager.shutdown()
 
     logging.getLogger(__name__).info("All %d jobs done", total_job_count)
     _log_area_hectare_assumptions()

--- a/runner.py
+++ b/runner.py
@@ -14,7 +14,6 @@ import os
 import queue
 import shutil
 import tempfile
-import time
 
 from tqdm import tqdm
 from datasketches import kll_floats_sketch
@@ -57,18 +56,13 @@ VALID_OPERATIONS = {
 
 
 def _emit_progress(progress_queue, event):
-    """Send a progress event if a queue is configured.
+    """Send a progress event to the monitor.
 
     Args:
-        progress_queue: Queue-like object receiving progress events, or `None`.
+        progress_queue: Queue-like object receiving progress events.
         event: Pickleable event dictionary for the progress monitor.
     """
-    if progress_queue is None:
-        return
-    try:
-        progress_queue.put(event)
-    except Exception:
-        logger.exception("failed to emit progress event: %s", event)
+    progress_queue.put(event)
 
 
 def _progress_monitor(progress_queue, total_jobs):
@@ -144,6 +138,15 @@ def _progress_monitor(progress_queue, total_jobs):
                 increment = event.get("increment", 1)
                 if increment:
                     progress_bar.update(increment)
+                phase = event.get("phase")
+                if phase:
+                    progress_bar.set_postfix_str(phase, refresh=True)
+                continue
+
+            if event_type == "analysis_set":
+                value = event.get("value", progress_bar.n)
+                if value > progress_bar.n:
+                    progress_bar.update(value - progress_bar.n)
                 phase = event.get("phase")
                 if phase:
                     progress_bar.set_postfix_str(phase, refresh=True)
@@ -337,6 +340,9 @@ def _rasterize_aggregate_fids(
     aggregate_layer_name,
     target_raster_path,
     target_nodata,
+    progress_queue,
+    progress_id,
+    progress_start_value,
 ):
     """Rasterize prepared aggregation feature IDs onto the base raster grid."""
     target_raster_path = Path(target_raster_path)
@@ -363,8 +369,11 @@ def _rasterize_aggregate_fids(
     if feature_id_raster_dataset is None:
         raise RuntimeError(f"Could not open target raster at {target_raster_path}")
 
-    rasterize_callback = _make_logger_callback(
-        "rasterizing polygons %.1f%% complete %s"
+    rasterize_callback = _make_progress_callback(
+        progress_queue,
+        progress_id,
+        "rasterizing polygons",
+        progress_start_value,
     )
     aggregate_layer.ResetReading()
     logger.info("rasterize start")
@@ -389,50 +398,39 @@ def _rasterize_aggregate_fids(
     logger.info("rasterize done")
 
 
-def _make_logger_callback(message):
-    """Build a timed logger callback that prints ``message`` replaced.
+def _make_progress_callback(progress_queue, progress_id, phase, start_value=0):
+    """Build a GDAL callback that emits integer percentage progress events.
 
     Args:
-        message (string): a string that expects 2 placement %% variables,
-            first for % complete from ``df_complete``, second from
-            ``p_progress_arg[0]``.
+        progress_queue: Queue-like object receiving progress events.
+        progress_id: Progress bar identifier to update.
+        phase: Human-readable phase label for the progress bar.
+        start_value: Existing progress bar value before this callback starts.
 
-    Return:
-        Function with signature:
-            logger_callback(df_complete, psz_message, p_progress_arg)
-
+    Returns:
+        GDAL-compatible callback that returns 1 to keep processing.
     """
 
-    def logger_callback(df_complete, _, p_progress_arg):
-        """Argument names come from the GDAL API for callbacks."""
-        try:
-            current_time = time.time()
-            if (current_time - logger_callback.last_time) > 5.0 or (
-                df_complete == 1.0 and logger_callback.total_time >= 5.0
-            ):
-                # In some multiprocess applications I was encountering a
-                # ``p_progress_arg`` of None. This is unexpected and I suspect
-                # was an issue for some kind of GDAL race condition. So I'm
-                # guarding against it here and reporting an appropriate log
-                # if it occurs.
-                if p_progress_arg:
-                    logger.info(message, df_complete * 100, p_progress_arg[0])
-                else:
-                    logger.info(message, df_complete * 100, "")
-                logger_callback.last_time = current_time
-                logger_callback.total_time += current_time
-        except AttributeError:
-            logger_callback.last_time = time.time()
-            logger_callback.total_time = 0.0
-        except Exception:
-            logger.exception(
-                "Unhandled error occurred while logging "
-                "progress.  df_complete: %s, p_progress_arg: %s",
-                df_complete,
-                p_progress_arg,
+    def progress_callback(df_complete, _, __):
+        """Argument names follow the GDAL callback API."""
+        complete_percent = int(round(df_complete * 100.0))
+        complete_percent = min(max(complete_percent, 0), 100)
+        increment = complete_percent - progress_callback.last_percent
+        if increment > 0:
+            _emit_progress(
+                progress_queue,
+                {
+                    "event": "analysis_set",
+                    "id": progress_id,
+                    "value": start_value + complete_percent,
+                    "phase": f"{phase} {complete_percent}%",
+                },
             )
+            progress_callback.last_percent = complete_percent
+        return 1
 
-    return logger_callback
+    progress_callback.last_percent = 0
+    return progress_callback
 
 
 def parse_and_validate_config(cfg_path: Path) -> dict:
@@ -814,16 +812,13 @@ def fast_zonal_statistics(
     clean_working_dir=False,
     percentile_list=None,
     calculate_area_ha=False,
-    progress_queue=None,
-    progress_id=None,
+    *,
+    progress_queue,
+    progress_id,
 ):
     raster_path, raster_band_index = base_raster_path_band
     aggregate_vector_fields = aggregate_vector_field
     aggregate_vector_field_label = ",".join(aggregate_vector_fields)
-    progress_id = (
-        progress_id
-        or f"raster:{Path(raster_path).stem}:{Path(aggregate_vector_path).stem}"
-    )
     progress_n = 0
     _emit_progress(
         progress_queue,
@@ -1090,6 +1085,7 @@ def fast_zonal_statistics(
         aggregate_layer = None
         aggregate_vector = None
 
+        rasterize_start_progress = progress_n
         rasterize_task = local_task_graph.add_task(
             func=_rasterize_aggregate_fids,
             args=(
@@ -1098,13 +1094,35 @@ def fast_zonal_statistics(
                 aggregate_layer_name,
                 feature_id_raster_path,
                 feature_id_raster_nodata,
+                progress_queue,
+                progress_id,
+                rasterize_start_progress,
             ),
             dependent_task_list=[prepare_vector_task],
             target_path_list=[feature_id_raster_path],
             task_name=f"rasterize aggregate fids for {Path(raster_path).stem}",
         )
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_total",
+                "id": progress_id,
+                "total": progress_n + 101,
+                "unit": "step",
+                "phase": "rasterizing polygons",
+            },
+        )
         rasterize_task.join()
-        progress_n += 1
+        _emit_progress(
+            progress_queue,
+            {
+                "event": "analysis_set",
+                "id": progress_id,
+                "value": rasterize_start_progress + 100,
+                "phase": "preparing raster blocks",
+            },
+        )
+        progress_n += 100
         _emit_progress(
             progress_queue,
             {
@@ -1114,6 +1132,7 @@ def fast_zonal_statistics(
                 "phase": "preparing raster blocks",
             },
         )
+        progress_n += 1
 
         feature_id_raster_offsets = list(
             geoprocessing.iterblocks(
@@ -1390,7 +1409,7 @@ def run_vector_stats_job(
     workdir: Path,
     tag: str,
     job_type: str,
-    progress_queue=None,
+    progress_queue,
 ):
     """Run a vector-based statistics job and write aggregated results to CSV.
 
@@ -1419,7 +1438,7 @@ def run_vector_stats_job(
         workdir: Working directory for intermediate job artifacts.
         tag: Job identifier used for logging and column name suffixes.
         job_type: Job type string; must be `"vector"`.
-        progress_queue: Optional queue for progress monitor events.
+        progress_queue: Queue for progress monitor events.
 
     Raises:
         ValueError: If `job_type` is not `"vector"` or if operation parsing fails.
@@ -1919,7 +1938,7 @@ def run_vector_measure_job(
     operation,
     measure_crs,
     tag,
-    progress_queue=None,
+    progress_queue,
 ):
     """Run a vector-on-vector intersection measure job.
 
@@ -1933,7 +1952,7 @@ def run_vector_measure_job(
             `intersect_count`.
         measure_crs: CRS for planar measurement, or `auto`.
         tag: Job tag used in log and error messages.
-        progress_queue: Optional queue for progress monitor events.
+        progress_queue: Queue for progress monitor events.
 
     Returns:
         DataFrame containing aggregation fields and one measure column.
@@ -2164,7 +2183,7 @@ def run_zonal_stats_job(
     workdir: Path,
     tag: str,
     task_graph,
-    progress_queue=None,
+    progress_queue,
 ):
     """Run a zonal statistics job over raster and/or vector base datasets.
 
@@ -2196,7 +2215,7 @@ def run_zonal_stats_job(
         workdir: Working directory for intermediate files and task graph outputs.
         tag: Job identifier used for temporary filenames and task labeling.
         task_graph: Task graph instance used to schedule raster and vector jobs.
-        progress_queue: Optional queue for progress monitor events.
+        progress_queue: Queue for progress monitor events.
 
     Raises:
         ValueError: If operation parsing fails or required inputs are inconsistent.

--- a/runner.py
+++ b/runner.py
@@ -55,16 +55,6 @@ VALID_OPERATIONS = {
 }
 
 
-def _emit_progress(progress_queue, event):
-    """Send a progress event to the monitor.
-
-    Args:
-        progress_queue: Queue-like object receiving progress events.
-        event: Pickleable event dictionary for the progress monitor.
-    """
-    progress_queue.put(event)
-
-
 def _progress_monitor(progress_queue, total_jobs):
     """Render runner progress events as tqdm bars.
 
@@ -417,8 +407,7 @@ def _make_progress_callback(progress_queue, progress_id, phase, start_value=0):
         complete_percent = min(max(complete_percent, 0), 100)
         increment = complete_percent - progress_callback.last_percent
         if increment > 0:
-            _emit_progress(
-                progress_queue,
+            progress_queue.put(
                 {
                     "event": "analysis_set",
                     "id": progress_id,
@@ -820,8 +809,7 @@ def fast_zonal_statistics(
     aggregate_vector_fields = aggregate_vector_field
     aggregate_vector_field_label = ",".join(aggregate_vector_fields)
     progress_n = 0
-    _emit_progress(
-        progress_queue,
+    progress_queue.put(
         {
             "event": "analysis_start",
             "id": progress_id,
@@ -961,8 +949,7 @@ def fast_zonal_statistics(
         )
         prepare_vector_task.join()
         progress_n += 1
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_update",
                 "id": progress_id,
@@ -1007,8 +994,7 @@ def fast_zonal_statistics(
             len(unique_group_values),
         )
         progress_n += 1
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_update",
                 "id": progress_id,
@@ -1051,8 +1037,7 @@ def fast_zonal_statistics(
                 len(unique_group_values),
             )
             aggregate_layer = None
-            _emit_progress(
-                progress_queue,
+            progress_queue.put(
                 {
                     "event": "analysis_close",
                     "id": progress_id,
@@ -1102,8 +1087,7 @@ def fast_zonal_statistics(
             target_path_list=[feature_id_raster_path],
             task_name=f"rasterize aggregate fids for {Path(raster_path).stem}",
         )
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_total",
                 "id": progress_id,
@@ -1113,8 +1097,7 @@ def fast_zonal_statistics(
             },
         )
         rasterize_task.join()
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_set",
                 "id": progress_id,
@@ -1123,8 +1106,7 @@ def fast_zonal_statistics(
             },
         )
         progress_n += 100
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_update",
                 "id": progress_id,
@@ -1145,8 +1127,7 @@ def fast_zonal_statistics(
             "iterblocks prepared | blocks=%d",
             len(feature_id_raster_offsets),
         )
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_total",
                 "id": progress_id,
@@ -1166,8 +1147,7 @@ def fast_zonal_statistics(
         if percentile_list:
             group_sketch = defaultdict(lambda: kll_floats_sketch(k=200))
         for block_index, feature_id_offset in enumerate(feature_id_raster_offsets):
-            _emit_progress(
-                progress_queue,
+            progress_queue.put(
                 {
                     "event": "analysis_update",
                     "id": progress_id,
@@ -1228,8 +1208,7 @@ def fast_zonal_statistics(
 
         logger.info("aggregating done")
         progress_n += len(feature_id_raster_offsets)
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_update",
                 "id": progress_id,
@@ -1382,8 +1361,7 @@ def fast_zonal_statistics(
             )
         logger.info("grouping done | groups=%d", len(grouped_stats))
         logger.info("fast_zonal_statistics done")
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_close",
                 "id": progress_id,
@@ -1514,8 +1492,7 @@ def run_vector_stats_job(
         base_vector_path = Path(base_vector_path)
         stem = base_vector_path.stem
         progress_id = f"vector:{tag}:{stem}"
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_start",
                 "id": progress_id,
@@ -1538,8 +1515,7 @@ def run_vector_stats_job(
             base_gdf = base_gdf.to_crs(agg_crs)
 
         transformers_by_stem[stem] = transformer
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_update",
                 "id": progress_id,
@@ -1574,8 +1550,7 @@ def run_vector_stats_job(
             )
             for start_index in range(0, feature_count, chunk_size)
         ]
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_total",
                 "id": progress_id,
@@ -1589,8 +1564,7 @@ def run_vector_stats_job(
             for chunk_index, (start_index, nearest_chunk) in enumerate(
                 executor.map(_nearest_chunk_thread, nearest_tasks, chunksize=1),
             ):
-                _emit_progress(
-                    progress_queue,
+                progress_queue.put(
                     {
                         "event": "analysis_update",
                         "id": progress_id,
@@ -1617,8 +1591,7 @@ def run_vector_stats_job(
         }
 
         stem_frame = pd.DataFrame(group_keys, columns=agg_fields)
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_update",
                 "id": progress_id,
@@ -1731,8 +1704,7 @@ def run_vector_stats_job(
                         stem_frame[column_name] = out
 
         per_stem_frames.append(stem_frame)
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_close",
                 "id": progress_id,
@@ -1958,8 +1930,7 @@ def run_vector_measure_job(
         DataFrame containing aggregation fields and one measure column.
     """
     progress_id = f"measure:{tag}:{Path(base_measure_vector).stem}"
-    _emit_progress(
-        progress_queue,
+    progress_queue.put(
         {
             "event": "analysis_start",
             "id": progress_id,
@@ -1978,8 +1949,7 @@ def run_vector_measure_job(
     )
     agg_gdf = gpd.read_file(agg_vector, layer=agg_layer)
     measure_gdf = gpd.read_file(base_measure_vector, layer=base_measure_layer)
-    _emit_progress(
-        progress_queue,
+    progress_queue.put(
         {
             "event": "analysis_update",
             "id": progress_id,
@@ -1992,8 +1962,7 @@ def run_vector_measure_job(
     ].copy()
     _validate_measure_geometry(measure_gdf, operation, base_measure_vector)
 
-    _emit_progress(
-        progress_queue,
+    progress_queue.put(
         {
             "event": "analysis_update",
             "id": progress_id,
@@ -2009,8 +1978,7 @@ def run_vector_measure_job(
 
     if measure_gdf.empty:
         logger.info("base measure vector has no non-empty geometries")
-        _emit_progress(
-            progress_queue,
+        progress_queue.put(
             {
                 "event": "analysis_close",
                 "id": progress_id,
@@ -2022,8 +1990,7 @@ def run_vector_measure_job(
     target_crs = _select_measure_crs(
         agg_groups, measure_gdf, measure_crs, operation, tag
     )
-    _emit_progress(
-        progress_queue,
+    progress_queue.put(
         {
             "event": "analysis_update",
             "id": progress_id,
@@ -2034,8 +2001,7 @@ def run_vector_measure_job(
     agg_projected = agg_groups.to_crs(target_crs)
     measure_projected = measure_gdf[["geometry"]].to_crs(target_crs)
     measure_projected = measure_projected.explode(index_parts=False)
-    _emit_progress(
-        progress_queue,
+    progress_queue.put(
         {
             "event": "analysis_update",
             "id": progress_id,
@@ -2052,8 +2018,7 @@ def run_vector_measure_job(
             predicate="intersects",
         )
         if joined.empty:
-            _emit_progress(
-                progress_queue,
+            progress_queue.put(
                 {
                     "event": "analysis_close",
                     "id": progress_id,
@@ -2075,8 +2040,7 @@ def run_vector_measure_job(
             keep_geom_type=False,
         )
         if intersection_gdf.empty:
-            _emit_progress(
-                progress_queue,
+            progress_queue.put(
                 {
                     "event": "analysis_close",
                     "id": progress_id,
@@ -2101,8 +2065,7 @@ def run_vector_measure_job(
             .sum()
             .reset_index()
         )
-    _emit_progress(
-        progress_queue,
+    progress_queue.put(
         {
             "event": "analysis_update",
             "id": progress_id,
@@ -2117,8 +2080,7 @@ def run_vector_measure_job(
     result_table[column_name] = result_table[column_name].fillna(0)
     if operation == "intersect_count":
         result_table[column_name] = result_table[column_name].astype(np.int64)
-    _emit_progress(
-        progress_queue,
+    progress_queue.put(
         {
             "event": "analysis_close",
             "id": progress_id,
@@ -2402,8 +2364,7 @@ def main():
             logger.exception("job failed for output %s", output_label)
             thread_error_list.append((output_label, error))
         finally:
-            _emit_progress(
-                job_kwargs.get("progress_queue"),
+            job_kwargs["progress_queue"].put(
                 {
                     "event": "job_done",
                     "tag": job_kwargs.get("tag"),
@@ -2474,7 +2435,7 @@ def main():
         task_graph.join()
         task_graph.close()
     finally:
-        _emit_progress(progress_queue, {"event": "stop"})
+        progress_queue.put({"event": "stop"})
         progress_thread.join()
         progress_manager.shutdown()
 


### PR DESCRIPTION
## Summary

Closes #31.

Adds default tqdm progress reporting for runner execution:

- a primary progress bar for completed `[job:...]` sections
- per-analysis bars for raster, vector-attribute, and vector-measure work
- raster phases for vector prep, vector scan, rasterization, block processing, and grouping
- vector-attribute phases for reading, nearest-neighbor chunks, and summarizing attributes
- vector-measure phases for reading, validation, dissolve, projection, intersection, and result merge
- TaskGraph reporting intervals set to `None` so TaskGraph status output does not compete with tqdm bars

Progress events are emitted from worker tasks and rendered by a single monitor thread, so TaskGraph process workers do not directly own terminal progress bars.

## Testing

- `python -m py_compile runner.py`
- `git diff --check`
- Verified installed TaskGraph signature supports `reporting_interval=None`
- Ran a synthetic progress-monitor smoke test with thread-local queue events

## Known limitations / follow-up

- I did not run a full production zonal statistics job in this environment.
- A Manager queue smoke test from stdin is not representative on Windows because `multiprocessing.Manager()` cannot spawn from `<stdin>`; the runner itself executes from a file path.