### PR TITLE
Add native mamba environment

### DIFF
--- a/environment-runner.yml
+++ b/environment-runner.yml
@@ -1,0 +1,42 @@
+# Native mamba environment for running zonal_stats_toolkit without Docker.
+#
+# Create:
+#   mamba env create -f environment-runner.yml
+#
+# Update after edits:
+#   mamba env update -f environment-runner.yml --prune
+#
+# Run:
+#   mamba activate zonal-stats-toolkit
+#   python runner.py path\to\job.yaml
+#
+# Keep GDAL/Fiona/GeoPandas/Shapely/PyProj on conda-forge. Installing those
+# packages from pip on Windows is much more likely to create binary-library
+# conflicts.
+name: zonal-stats-toolkit
+channels:
+  - conda-forge
+dependencies:
+  - python=3.11
+  - pip
+  - gdal
+  - fiona
+  - geopandas
+  - numpy
+  - pandas
+  - pyproj
+  - rasterio
+  - rtree
+  - scipy
+  - shapely
+  - tqdm
+  - cython
+  - numexpr
+  - psutil
+  - pyyaml
+  - retrying
+  - setuptools
+  - wheel
+  - pip:
+      - datasketches
+      - git+https://github.com/springinnovate/ecoshard.git


### PR DESCRIPTION
## Summary
- Adds `environment-runner.yml` for running zonal_stats_toolkit directly with mamba/conda outside Docker.
- Keeps the geospatial binary stack on `conda-forge` for Windows compatibility.
- Includes usage comments for creating, updating, activating, and running the environment.

Closes #38.

## Testing
- Parsed `environment-runner.yml` with PyYAML using the local py39 conda interpreter.
- `git diff --check`

## Notes
- I did not run a full `mamba env create` because that would download packages from conda-forge and GitHub. The file installs `ecoshard` from the same GitHub source used by the Dockerfile.