### PR TITLE
Suppress GDAL coordinate operation warnings

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -421,6 +421,7 @@ def _prepare_aggregate_vector_for_rasterization(
             str(tmp_reprojected_path),
             src_path,
             dstSRS=raster_projection_wkt,
+            options=["-ct_opt", "WARN_ABOUT_DIFFERENT_COORD_OP=NO"],
             **vector_translate_kwargs,
         )
         src_path = str(tmp_reprojected_path)


### PR DESCRIPTION
## Summary
- Add GDAL's `WARN_ABOUT_DIFFERENT_COORD_OP=NO` coordinate-transform option to the aggregation-vector reprojection step.
- Keep the suppression scoped to the VectorTranslate call that intentionally reprojects vectors for rasterization, so the advisory no longer writes through tqdm progress bars.

Closes #44.

## Testing
- `python -m py_compile runner.py`
- `C:\Users\richp\mambaforge\envs\zonal-stats-toolkit\python.exe -c "from osgeo import gdal; opts = gdal.VectorTranslateOptions(format='GPKG', geometryType='PROMOTE_TO_MULTI', dstSRS='EPSG:4326', options=['-ct_opt', 'WARN_ABOUT_DIFFERENT_COORD_OP=NO']); print(type(opts).__name__)"`
- `C:\Users\richp\mambaforge\envs\zonal-stats-toolkit\python.exe -c "from osgeo import gdal; gdal.UseExceptions();\ntry:\n    gdal.VectorTranslate('/vsimem/out.gpkg', '/vsimem/missing.gpkg', dstSRS='EPSG:4326', format='GPKG', geometryType='PROMOTE_TO_MULTI', options=['-ct_opt', 'WARN_ABOUT_DIFFERENT_COORD_OP=NO'])\nexcept Exception as error:\n    print(type(error).__name__); print(str(error).splitlines()[0])"`
- `git diff --check`

## Known Limitations
- I did not rerun the full 15-job workflow locally because the change is limited to GDAL option wiring and the full workflow depends on the large local assessment inputs.