### PR TITLE
Improve progress feedback during raster jobs

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -217,7 +217,9 @@ def _progress_monitor(progress_queue, total_jobs):
         total_jobs: Number of `[job:...]` sections expected to finish.
     """
     bars = {}
+    bar_descriptions = {}
     next_position = 1
+    active_job_tag = None
     job_bar = tqdm(
         total=total_jobs,
         desc="jobs",
@@ -237,6 +239,11 @@ def _progress_monitor(progress_queue, total_jobs):
             if event_type == "stop":
                 break
 
+            if event_type == "job_start":
+                active_job_tag = event.get("tag", "job")
+                job_bar.set_postfix_str(f"{active_job_tag} running", refresh=True)
+                continue
+
             if event_type == "job_done":
                 job_bar.update(1)
                 job_bar.set_postfix_str(
@@ -249,12 +256,27 @@ def _progress_monitor(progress_queue, total_jobs):
             if not progress_id:
                 continue
 
+            def _show_active_phase(phase, active_label=None):
+                """Set the top-level job bar to the current analysis phase."""
+                if not phase:
+                    return
+                active_label = active_label or bar_descriptions.get(
+                    progress_id, progress_id
+                )
+                job_prefix = f"{active_job_tag}: " if active_job_tag else ""
+                job_bar.set_postfix_str(
+                    f"{job_prefix}{active_label} - {phase}",
+                    refresh=True,
+                )
+
             if event_type == "analysis_start":
                 if progress_id in bars:
                     bars[progress_id].close()
+                desc = event.get("desc", progress_id)
+                bar_descriptions[progress_id] = desc
                 bars[progress_id] = tqdm(
                     total=event.get("total", 1),
-                    desc=event.get("desc", progress_id),
+                    desc=desc,
                     unit=event.get("unit", "step"),
                     position=next_position,
                     leave=True,
@@ -263,6 +285,7 @@ def _progress_monitor(progress_queue, total_jobs):
                 phase = event.get("phase")
                 if phase:
                     bars[progress_id].set_postfix_str(phase, refresh=True)
+                    _show_active_phase(phase, desc)
                 continue
 
             progress_bar = bars.get(progress_id)
@@ -275,6 +298,7 @@ def _progress_monitor(progress_queue, total_jobs):
                 phase = event.get("phase")
                 if phase:
                     progress_bar.set_postfix_str(phase, refresh=True)
+                    _show_active_phase(phase)
                 progress_bar.refresh()
                 continue
 
@@ -285,6 +309,7 @@ def _progress_monitor(progress_queue, total_jobs):
                 phase = event.get("phase")
                 if phase:
                     progress_bar.set_postfix_str(phase, refresh=True)
+                    _show_active_phase(phase)
                 continue
 
             if event_type == "analysis_set":
@@ -294,12 +319,14 @@ def _progress_monitor(progress_queue, total_jobs):
                 phase = event.get("phase")
                 if phase:
                     progress_bar.set_postfix_str(phase, refresh=True)
+                    _show_active_phase(phase)
                 continue
 
             if event_type == "analysis_close":
                 phase = event.get("phase")
                 if phase:
                     progress_bar.set_postfix_str(phase, refresh=True)
+                    _show_active_phase(phase)
                 if (
                     progress_bar.total is not None
                     and progress_bar.n < progress_bar.total
@@ -827,11 +854,19 @@ def _rasterize_aggregate_fids(
             {
                 "event": "analysis_update",
                 "id": progress_id,
-                "increment": 1,
+                "increment": 0,
                 "phase": "stitching rasterized tiles",
             },
         )
         _stitch_raster_tiles(target_raster_path, tile_specs)
+        progress_queue.put(
+            {
+                "event": "analysis_update",
+                "id": progress_id,
+                "increment": 1,
+                "phase": "stitched rasterized tiles",
+            },
+        )
     finally:
         shutil.rmtree(tile_dir, ignore_errors=True)
     logger.debug("rasterize done")
@@ -2860,6 +2895,7 @@ def main():
             status = "done"
             try:
                 job["progress_queue"] = progress_queue
+                progress_queue.put({"event": "job_start", "tag": tag})
                 with ProcessPoolExecutor(
                     max_workers=1,
                     mp_context=process_context,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -22,6 +22,15 @@ def _projection_wkt(epsg):
     return srs.ExportToWkt()
 
 
+def _drain_queue(progress_queue):
+    events = []
+    while True:
+        try:
+            events.append(progress_queue.get_nowait())
+        except queue.Empty:
+            return events
+
+
 def _write_raster(path, array, *, epsg=6933, nodata=-1, origin=(0, 4), pixel_size=1):
     path = Path(path)
     driver = gdal.GetDriverByName("GTiff")
@@ -391,6 +400,22 @@ def test_prepare_and_rasterize_aggregate_fids(
     assert np.all(array[:, :2] == 1)
     assert np.all(array[:, 2:] == 2)
 
+    events = _drain_queue(progress_queue)
+    stitch_events = [
+        event
+        for event in events
+        if event.get("phase") in {
+            "stitching rasterized tiles",
+            "stitched rasterized tiles",
+        }
+    ]
+    assert [
+        (event["phase"], event["increment"]) for event in stitch_events
+    ] == [
+        ("stitching rasterized tiles", 0),
+        ("stitched rasterized tiles", 1),
+    ]
+
 
 def test_rasterize_aggregate_fids_can_spawn_from_job_process(
     tmp_path, projected_zone_vector, projected_raster, multiprocessing_queue
@@ -721,6 +746,74 @@ def test_progress_monitor_stops_cleanly():
     progress_queue = queue.Queue()
     progress_queue.put({"event": "stop"})
     runner._progress_monitor(progress_queue, total_jobs=1)
+
+
+def test_progress_monitor_shows_active_job_phase(monkeypatch):
+    class FakeTqdm:
+        instances = []
+
+        def __init__(self, total, desc, unit, position, leave):
+            self.total = total
+            self.desc = desc
+            self.unit = unit
+            self.position = position
+            self.leave = leave
+            self.n = 0
+            self.postfix_values = []
+            self.closed = False
+            FakeTqdm.instances.append(self)
+
+        def update(self, increment):
+            self.n += increment
+
+        def set_postfix_str(self, value, refresh=True):
+            self.postfix_values.append(value)
+
+        def refresh(self):
+            pass
+
+        def close(self):
+            self.closed = True
+
+    progress_queue = queue.Queue()
+    progress_queue.put({"event": "job_start", "tag": "counties_ecosystem_services"})
+    progress_queue.put(
+        {
+            "event": "analysis_start",
+            "id": "raster:counties_ecosystem_services:annual_value",
+            "desc": "raster annual_value",
+            "total": 4,
+            "phase": "scanning aggregation vector",
+        }
+    )
+    progress_queue.put(
+        {
+            "event": "analysis_update",
+            "id": "raster:counties_ecosystem_services:annual_value",
+            "increment": 0,
+            "phase": "stitching rasterized tiles",
+        }
+    )
+    progress_queue.put(
+        {
+            "event": "job_done",
+            "tag": "counties_ecosystem_services",
+            "status": "done",
+        }
+    )
+    progress_queue.put({"event": "stop"})
+
+    monkeypatch.setattr(runner, "tqdm", FakeTqdm)
+
+    runner._progress_monitor(progress_queue, total_jobs=1)
+
+    job_bar = FakeTqdm.instances[0]
+    assert "counties_ecosystem_services running" in job_bar.postfix_values
+    assert (
+        "counties_ecosystem_services: raster annual_value - "
+        "stitching rasterized tiles"
+    ) in job_bar.postfix_values
+    assert "counties_ecosystem_services done" in job_bar.postfix_values
 
 
 def test_main_returns_when_no_jobs(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Show the currently running job and active analysis phase on the top-level jobs progress bar.
- Keep rasterization progress below complete while tile stitching is still running.
- Preserve the human-readable analysis description across progress updates.

## Related Issue
Resolves #53

## Testing
- `C:\Users\richp\mambaforge\envs\zonal-stats-toolkit\python.exe -m pytest tests\test_runner.py -q`

## Notes
- Test run passed with existing `pyogrio`/`GDAL_DATA` runtime warnings.