### PR TITLE
Resolve output paths relative to config

### DIFF
--- a/runner.py
+++ b/runner.py
@@ -1095,12 +1095,14 @@ def parse_and_validate_config(cfg_path: Path) -> dict:
                     f"Available fields: {sorted(props.keys())}"
                 )
 
-        output_csv = job.get("output_csv", "").strip()
-        output_gpkg = job.get("output_gpkg", "").strip()
-        if not output_csv and not output_gpkg:
+        output_csv_raw = job.get("output_csv", "").strip()
+        output_gpkg_raw = job.get("output_gpkg", "").strip()
+        if not output_csv_raw and not output_gpkg_raw:
             raise ValueError(
                 f"[job:{tag}] must define at least one of output_csv or output_gpkg"
             )
+        output_csv = _abs_from_cfg_dir(output_csv_raw) if output_csv_raw else None
+        output_gpkg = _abs_from_cfg_dir(output_gpkg_raw) if output_gpkg_raw else None
 
         workdir = global_work_dir / Path(tag)
         workdir.mkdir(parents=True, exist_ok=True)
@@ -1220,8 +1222,8 @@ def parse_and_validate_config(cfg_path: Path) -> dict:
                 "agg_field": agg_fields,
                 "operations": operations,
                 "workdir": workdir,
-                "output_csv": output_csv or None,
-                "output_gpkg": output_gpkg or None,
+                "output_csv": output_csv,
+                "output_gpkg": output_gpkg,
                 "base_raster_path_list": base_raster_path_list,
                 "base_vector_path_list": base_vector_path_list,
                 "base_vector_fields": base_vector_fields,

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -256,6 +256,7 @@ def test_parse_and_validate_config_resolves_paths(
                 "operations = sum, mean, total_count, valid_count, proportion_valid_nonzero",
                 f"base_raster_pattern = {projected_raster.name}",
                 "output_csv = output/results.csv",
+                "output_gpkg = output/results.gpkg",
             ]
         )
     )
@@ -266,7 +267,8 @@ def test_parse_and_validate_config_resolves_paths(
     assert job["agg_field"] == ["STATE", "COUNTY"]
     assert "proportion_valid_nonzero" in job["operations"]
     assert job["base_raster_path_list"] == [projected_raster]
-    assert job["output_csv"] == "output/results.csv"
+    assert job["output_csv"] == tmp_path / "output" / "results.csv"
+    assert job["output_gpkg"] == tmp_path / "output" / "results.gpkg"
     assert job["workdir"] == tmp_path / "work" / "raster_job"
 
 


### PR DESCRIPTION
## Summary
- Resolve relative `output_csv` and `output_gpkg` paths against the config file directory.
- Preserve absolute output paths unchanged through the existing shared path resolver.
- Update config parsing coverage so output path behavior matches input and workdir path behavior.

## Related Issue
Resolves #55

## Testing
- `C:\Users\richp\mambaforge\envs\zonal-stats-toolkit\python.exe -m pytest tests\test_runner.py -q`

## Notes
- Test run passed with existing `pyogrio`/`GDAL_DATA` runtime warnings.